### PR TITLE
fix: remove MYSQL_URL repeat in api/.env.example

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -3,7 +3,6 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=https://api.robowala.ca
-MYSQL_URL=
 CONSOLE_HOST="https://fleet.robowala.ca"
 SESSION_DOMAIN=".robowala.ca"
 


### PR DESCRIPTION
fix: remove MYSQL_URL repeat in api/.env.example